### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 'main.py'"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/Dogeek/rpg-text)](https://repl.it/github/Dogeek/rpg-text)
+
 # rpg-text
  An object-oriented text RPG based loosely on the rules of Original Dungeons and Dragons.
 


### PR DESCRIPTION
I configured this to run this on an in browser terminal through repl.it, it makes it super simple to play! Let me know if you'd consider adding the badge :) It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/rpg-text).

![Capture](https://user-images.githubusercontent.com/39810066/70552560-98e51780-1b47-11ea-8766-d7d3b1ee9239.PNG)
